### PR TITLE
Make Auth0 integration less side-effecty.

### DIFF
--- a/auth0/build.sbt
+++ b/auth0/build.sbt
@@ -10,7 +10,6 @@ scalacOptions := Seq(
 )
 
 libraryDependencies := Seq(
-  "com.squareup.okhttp3" % "okhttp"           % "3.9.0",
   "com.auth0"            % "auth0"            % "1.5.1",
   "com.auth0"            % "jwks-rsa"         % "0.3.0",
   "com.auth0"            % "java-jwt"         % "3.3.0",

--- a/auth0/src/main/scala/io/unsecurity/auth/auth0/oidc/Auth0OidcSecurityContext.scala
+++ b/auth0/src/main/scala/io/unsecurity/auth/auth0/oidc/Auth0OidcSecurityContext.scala
@@ -1,36 +1,35 @@
-package io.unsecurity.auth.auth0.oidc
+package io.unsecurity
+package auth.auth0
+package oidc
 
 import java.net.URI
-import java.security.SecureRandom
 import java.security.interfaces.RSAPublicKey
-import java.util.concurrent.TimeUnit
 
+import cats.data.EitherT
 import cats.effect.Sync
+import cats.syntax.functor._
 import com.auth0.client.auth.AuthAPI
-import com.auth0.jwk.{GuavaCachedJwkProvider, UrlJwkProvider}
+import com.auth0.jwk.JwkProvider
 import com.auth0.jwt.JWT
 import com.auth0.jwt.algorithms.Algorithm
 import com.auth0.jwt.interfaces.DecodedJWT
-import io.circe.{Decoder, Encoder, Json}
-import io.unsecurity.{SecurityContext, UnsecurityOps}
-import io.unsecurity.auth.auth0.AuthConfig
-import no.scalabin.http4s.directives.Directive
-import okhttp3.{MediaType, OkHttpClient, Request, RequestBody}
-import org.apache.commons.codec.binary.Hex
-import org.http4s.{RequestCookie, ResponseCookie, Status}
-import org.slf4j.{Logger, LoggerFactory}
-import io.circe.syntax._
 import io.circe.parser.{decode => cDecode}
+import io.circe.syntax._
+import io.circe.{Decoder, Encoder, Json}
 import io.unsecurity.auth.auth0.oidc.Jwt.JwtHeader
-import okio.ByteString
+import no.scalabin.http4s.directives.Directive
+import org.http4s._
+import org.http4s.client.Client
+import org.slf4j.{Logger, LoggerFactory}
+import scodec.bits.BitVector
 
-class Auth0OidcSecurityContext[F[_] : Sync, U](val authConfig: AuthConfig,
-                                               val sessionStore: SessionStore[OidcAuthenticatedUser],
-                                               lookup: OidcAuthenticatedUser => Option[U]
-                                              ) extends SecurityContext[F, OidcAuthenticatedUser, U]
-  with UnsecurityOps[F] {
+class Auth0OidcSecurityContext[F[_]: Sync, U](val authConfig: AuthConfig,
+                                              val sessionStore: SessionStore[F, OidcAuthenticatedUser],
+                                              client: Client[F],
+                                              lookup: OidcAuthenticatedUser => Option[U])
+    extends SecurityContext[F, OidcAuthenticatedUser, U]
+    with UnsecurityOps[F] {
   val log: Logger = LoggerFactory.getLogger(classOf[Auth0OidcSecurityContext[F, U]])
-  val client: OkHttpClient = new OkHttpClient
 
   override def transformUser(u: OidcAuthenticatedUser): Option[U] = lookup(u)
 
@@ -38,7 +37,7 @@ class Auth0OidcSecurityContext[F[_] : Sync, U](val authConfig: AuthConfig,
     log.trace("trying to authenticate")
     for {
       sessionCookie <- sessionCookie
-      userProfile <- userSession(sessionCookie)
+      userProfile   <- userSession(sessionCookie)
     } yield {
       userProfile
     }
@@ -56,52 +55,50 @@ class Auth0OidcSecurityContext[F[_] : Sync, U](val authConfig: AuthConfig,
   }
 
   def validateXsrf(xsrfHeader: String, xsrfCookievalue: String, xForwardedFor: Option[String]): Directive[F, String] = {
-    if (xsrfCookievalue == xsrfHeader) {
-      Directive.success(xsrfHeader)
-    } else {
-      log.error(
-        s"XsrfCookie does not match Xsrf header, possible CSRF-Attack! X-Forwarded-For: ${xForwardedFor.getOrElse("")}"
-      )
-      Directive.failure(
-        ResponseJson("xsrf check failed", Status.BadRequest)
-      )
-    }
+    Directive
+      .success(xsrfHeader)
+      .filter(hdr =>
+        (xsrfCookievalue == hdr).orF(
+          Sync[F].delay {
+            log.error(
+              s"XsrfCookie does not match Xsrf header, possible CSRF-Attack! X-Forwarded-For: ${xForwardedFor.getOrElse("")}"
+            )
+            ResponseJson("xsrf check failed", Status.BadRequest)
+          }
+      ))
   }
 
   def xsrfHeader(xForwardedFor: Option[String]): Directive[F, String] = {
     for {
       header <- requestHeader("x-xsrf-token")
-      xsrfToken <- header match {
-        case Some(xsrfToken) => Directive.success(xsrfToken.value)
-        case None =>
-          log.error("No x-xsrf-token header, possible CSRF-attack!")
-          Directive.failure(
-            ResponseJson(
-              s"No x-xsrf-token header found. X-Forwarded-For: ${xForwardedFor.getOrElse("")}",
-              Status.BadRequest
-            )
-          )
-      }
+      xsrfToken <- Directive.getOrElse(
+                    header,
+                    Sync[F].delay {
+                      log.error("No x-xsrf-token header, possible CSRF-attack!")
+                      ResponseJson(
+                        s"No x-xsrf-token header found. X-Forwarded-For: ${xForwardedFor.getOrElse("")}",
+                        Status.BadRequest
+                      )
+                    }
+                  )
     } yield {
-      xsrfToken
+      xsrfToken.value
     }
   }
 
   def xsrfCookie(): Directive[F, String] = {
     for {
-      cookies       <- requestCookies()
+      maybeCookie   <- request.cookie("xsrf-token")
       xForwardedfor <- requestHeader("X-Forwarded-For")
-      xsrfCookie <- cookies
-        .find(c => c.name == "xsrf-token") match {
-        case Some(xstrfCookie) => Directive.success(xstrfCookie.content)
-        case None =>
-          log.error(s"No xsrf-cookie, possible CSRF-Attack from ${xForwardedfor.map(_.value).getOrElse("")}")
-          Directive.failure(
-            ResponseJson("No xsrf-token cookie found", Status.BadRequest)
-          )
-      }
+      xsrfCookie <- Directive.getOrElse(
+                     maybeCookie, {
+                       log.error(
+                         s"No xsrf-cookie, possible CSRF-Attack from ${xForwardedfor.map(_.value).getOrElse("")}")
+                       Sync[F].pure(ResponseJson("No xsrf-token cookie found", Status.BadRequest))
+                     }
+                   )
     } yield {
-      xsrfCookie
+      xsrfCookie.content
     }
   }
 
@@ -111,12 +108,13 @@ class Auth0OidcSecurityContext[F[_] : Sync, U](val authConfig: AuthConfig,
   }
 
   def userSession(cookie: RequestCookie): Directive[F, OidcAuthenticatedUser] = {
-    sessionStore.getSession(cookie.content) match {
-      case Some(user) => Directive.success(user)
-      case None =>
+    Directive.getOrElseF(
+      sessionStore.getSession(cookie.content),
+      Sync[F].delay {
         log.warn("Could not extract user profile: {}, session timed out")
-        Unauthorized("Could not extract user profile from the cookie")
-    }
+        unauthorizedResponse("Could not extract user profile from the cookie")
+      }
+    )
   }
 
   def createAuth0Url(state: String, auth0CallbackUrl: URI): String = {
@@ -129,20 +127,24 @@ class Auth0OidcSecurityContext[F[_] : Sync, U](val authConfig: AuthConfig,
   }
 
   def validateState(stateCookie: RequestCookie, state: String, xForwardedFor: Option[String]): Directive[F, State] = {
-    sessionStore.getState(stateCookie.content) match {
-      case None =>
-        log.error(s"Invalid state, possible CSRF-attack on login. X-Forwarded-For: ${xForwardedFor.getOrElse("")}")
-        BadRequest("Invalid state, possible csrf-attack")
-      case Some(sessionState) =>
-        if (state == sessionState.state) {
-          Directive.success(sessionState)
-        } else {
+    for {
+      sessionState <- Directive.getOrElseF(
+                       sessionStore.getState(stateCookie.content),
+                       Sync[F].delay {
+                         log.error(
+                           s"Invalid state, possible CSRF-attack on login. X-Forwarded-For: ${xForwardedFor.getOrElse("")}")
+                         ResponseJson("Invalid state, possible csrf-attack", Status.BadRequest)
+                       }
+                     )
+      if (state == sessionState.state).orF(
+        Sync[F].delay {
           log.error(
             s"State values does not match, possible XSRF-attack! X-Forwarded-For: ${xForwardedFor.getOrElse("")} "
           )
-          BadRequest("Illegal state value")
+          ResponseJson("Illegal state value", Status.BadRequest)
         }
-    }
+      )
+    } yield sessionState
   }
 
   def isReturnUrlWhitelisted(uri: URI): Boolean = {
@@ -151,121 +153,122 @@ class Auth0OidcSecurityContext[F[_] : Sync, U](val authConfig: AuthConfig,
 
   def sessionCookie: Directive[F, RequestCookie] = {
     for {
-      cookies <- requestCookies()
-      cookie <- cookies
-        .find(c => c.name == authConfig.cookieName)
-        .map(c => Directive.success(c))
-        .getOrElse(
-          Directive.failure(ResponseJson("Session cookie not found. Please login", Status.Unauthorized))
-        )
+      maybeCookie <- request.cookie(authConfig.cookieName)
+      cookie <- Directive.getOrElse(
+                 maybeCookie,
+                 Sync[F].delay(ResponseJson("Session cookie not found. Please login", Status.Unauthorized)))
+
     } yield {
       cookie
     }
   }
 
   def fetchTokenFromAuth0(code: String, auth0CallbackUrl: URI): Directive[F, TokenResponse] = {
-    val tokenUrl: String = s"https://${authConfig.authDomain}/oauth/token"
-    val jsonMediaType: MediaType = MediaType.parse("application/json; charset=utf-8")
-    val payload: String = TokenRequest(grantType = "authorization_code",
-      clientId = authConfig.clientId,
-      clientSecret = authConfig.clientSecret,
-      code = code,
-      redirectUri = auth0CallbackUrl).asJson.noSpaces
-    val req: Request = new okhttp3.Request.Builder()
-      .url(tokenUrl)
-      .post(RequestBody.create(jsonMediaType, payload))
-      .build()
+    val tokenUrl      = Uri.unsafeFromString(s"https://${authConfig.authDomain}/oauth/token")
+    val jsonMediaType = MediaType.application.json
+    val payload = TokenRequest(grantType = "authorization_code",
+                               clientId = authConfig.clientId,
+                               clientSecret = authConfig.clientSecret,
+                               code = code,
+                               redirectUri = auth0CallbackUrl)
 
-    val resp = client.newCall(req).execute
-    val responseCode: Int = resp.code()
-    val body: String = resp.body.string
-    resp.body.close()
+    implicit val jsonEncoder: EntityEncoder[F, TokenRequest] = org.http4s.circe.jsonEncoderOf[F, TokenRequest]
 
-    if (responseCode == 200) {
-      cDecode[TokenResponse](body) match {
-        case Right(token) => Directive.success(token)
-        case Left(e) =>
-          log.error("Error parsing token from auth0 {}. Payload : {}", List(e, body): _*)
-          InternalServerError(Json.obj("msg" := "Error parsing token from auth0"))
-      }
-    } else {
-      log.error("Invalid response from auth0, got ({}) {}", responseCode, body)
-      InternalServerError(Json.obj("msg" := "Invalid response from IDP"))
-    }
+    val req = Request[F](
+      method = Method.POST,
+      uri = tokenUrl
+    ).withContentType(org.http4s.headers.`Content-Type`(jsonMediaType, Charset.`UTF-8`))
+      .withEntity(payload)
+
+    val res =
+      client.fetch(req)(res => res.attemptAs[String].fold(_ => res.status -> None, s => res.status -> Some(s)))
+
+    EitherT(
+      res
+        .map {
+          case (status, maybeBody) =>
+            if (status == Status.Ok) {
+              maybeBody
+                .toRight(Json.obj("msg" := "No data received from IdP"))
+                .flatMap(cDecode[TokenResponse](_).left.map { e =>
+                  log.error("Error parsing token from auth0 {}. Payload : {}", List(e, maybeBody.getOrElse("")): _*)
+                  Json.obj("msg" := "Error parsing token from auth0")
+                })
+            } else {
+              Left(Json.obj("msg" := "Invalid response from IDP"))
+            }
+        })
+      .toSuccess(ResponseJson(_, Status.InternalServerError))
   }
 
-  def verifyTokenAndGetOidcUser(tokenResponse: TokenResponse): Directive[F, OidcAuthenticatedUser] = {
-    def decodeBase64(value: String): String = ByteString.decodeBase64(value).utf8()
+  def verifyTokenAndGetOidcUser(tokenResponse: TokenResponse,
+                                jwkProvider: JwkProvider): Directive[F, OidcAuthenticatedUser] = {
+    def decodeBase64(value: String): String = BitVector.fromValidBase64(value).decodeUtf8.getOrElse("")
 
-    val numberOfKeys = 10
-
-    val provider: UrlJwkProvider = new UrlJwkProvider(s"https://${authConfig.authDomain}/.well-known/jwks.json")
-    val cachedProvider = new GuavaCachedJwkProvider(provider, numberOfKeys, 5L, TimeUnit.HOURS)
-    val decodedJwt: DecodedJWT = JWT.decode(tokenResponse.idToken)
-    val decodedHeaderString = decodeBase64(decodedJwt.getHeader)
+    val decodedJwt: DecodedJWT                         = JWT.decode(tokenResponse.idToken)
+    val decodedHeaderString                            = decodeBase64(decodedJwt.getHeader)
     val decodedEitherHeader: Either[String, JwtHeader] = cDecode[JwtHeader](decodedHeaderString).left.map(_.getMessage)
 
-    val eitherUser: Either[String, OidcAuthenticatedUser] = for {
-      header <- decodedEitherHeader
-      publicKey = cachedProvider.get(header.kid).getPublicKey.asInstanceOf[RSAPublicKey]
-      alg = Algorithm.RSA256(TokenVerifier.createPublicKeyProvider(publicKey))
-      oidcUser <- TokenVerifier.validateIdToken(alg, authConfig.authDomain, authConfig.clientId, tokenResponse.idToken)
+    val eitherUser: EitherT[F, String, OidcAuthenticatedUser] = for {
+      header    <- EitherT.fromEither(decodedEitherHeader)
+      publicKey <- EitherT.liftF(Sync[F].delay(jwkProvider.get(header.kid).getPublicKey.asInstanceOf[RSAPublicKey]))
+      alg       = Algorithm.RSA256(TokenVerifier.createPublicKeyProvider(publicKey))
+      oidcUser <- EitherT.fromEither(
+                   TokenVerifier
+                     .validateIdToken(alg, authConfig.authDomain, authConfig.clientId, tokenResponse.idToken))
     } yield {
       oidcUser
     }
 
-    eitherUser.fold(
-      errorMessage => InternalServerError(errorMessage),
-      user => Directive.success(user)
-    )
+    eitherUser.toSuccess(ResponseJson(_, Status.InternalServerError))
   }
 
-  def randomString(lengthInBytes: Int): String = {
-    val secrand: SecureRandom = new SecureRandom()
-    val byteArray: Array[Byte] = Array.fill[Byte](lengthInBytes)(0)
-    secrand.nextBytes(byteArray)
-
-    Hex.encodeHexString(byteArray)
+  def randomString(lengthInBytes: Int)(implicit randomProvider: RandomProvider[F]): F[String] = {
+    randomProvider.nextBytes(lengthInBytes).map(_.toHex)
   }
 
   object Cookies {
 
     object Keys {
-      val STATE: String = "statecookie"
+      val STATE: String        = "statecookie"
       val K_SESSION_ID: String = authConfig.cookieName
-      val XSRF: String = "xsrf-token"
+      val XSRF: String         = "xsrf-token"
     }
 
-    def createXsrfCookie(secureCookie: Boolean): ResponseCookie = {
-      val xsrfToken: String = randomString(32)
-      log.trace("xsrfToken: {}", xsrfToken)
-
-      ResponseCookie(
-        name = Keys.XSRF,
-        content = xsrfToken,
-        secure = secureCookie,
-        httpOnly = false,
-        path = Some("/"),
-        maxAge = Some(authConfig.sessionCookieTtl.toSeconds)
-      )
+    def createXsrfCookie(secureCookie: Boolean): F[ResponseCookie] = {
+      val xsrfToken = randomString(32)
+      xsrfToken.map { xsrf =>
+        log.trace("xsrfToken: {}", xsrf)
+        ResponseCookie(
+          name = Keys.XSRF,
+          content = xsrf,
+          secure = secureCookie,
+          httpOnly = false,
+          path = Some("/"),
+          maxAge = Some(authConfig.sessionCookieTtl.toSeconds)
+        )
+      }
     }
 
-    def createSessionCookie(secureCookie: Boolean): ResponseCookie = {
-      ResponseCookie(
-        name = Keys.K_SESSION_ID,
-        content = randomString(64),
-        secure = secureCookie,
-        path = Some("/"),
-        httpOnly = true,
-        maxAge = Some(authConfig.sessionCookieTtl.toSeconds)
-      )
+    def createSessionCookie(secureCookie: Boolean): F[ResponseCookie] = {
+      val cookie = randomString(64)
+      cookie.map { sessionId =>
+        ResponseCookie(
+          name = Keys.K_SESSION_ID,
+          content = sessionId,
+          secure = secureCookie,
+          path = Some("/"),
+          httpOnly = true,
+          maxAge = Some(authConfig.sessionCookieTtl.toSeconds)
+        )
+      }
     }
 
-    def createStateCookie(secureCookie: Boolean): ResponseCookie = {
-      val stateCookieRef: String = randomString(16)
-      log.trace("stateCookieRef: {}", stateCookieRef)
-
-      ResponseCookie(name = Cookies.Keys.STATE, content = stateCookieRef, secure = secureCookie)
+    def createStateCookie(secureCookie: Boolean): F[ResponseCookie] = {
+      randomString(16).map { state =>
+        log.trace("stateCookieRef: {}", state)
+        ResponseCookie(name = Cookies.Keys.STATE, content = state, secure = secureCookie)
+      }
     }
   }
 
@@ -291,9 +294,9 @@ object TokenResponse {
   implicit val tokenResponseDecoder: Decoder[TokenResponse] = Decoder { c =>
     for {
       accessToken <- c.downField("access_token").as[String]
-      expiresIn <- c.downField("expires_in").as[Long]
-      idToken <- c.downField("id_token").as[String]
-      tokenType <- c.downField("token_type").as[String]
+      expiresIn   <- c.downField("expires_in").as[Long]
+      idToken     <- c.downField("id_token").as[String]
+      tokenType   <- c.downField("token_type").as[String]
     } yield {
       TokenResponse(
         accessToken,

--- a/auth0/src/main/scala/io/unsecurity/auth/auth0/oidc/RandomProvider.scala
+++ b/auth0/src/main/scala/io/unsecurity/auth/auth0/oidc/RandomProvider.scala
@@ -1,0 +1,21 @@
+package io.unsecurity.auth.auth0.oidc
+import java.security.SecureRandom
+
+import cats.effect.Sync
+import scodec.bits.BitVector
+
+trait RandomProvider[F[_]] {
+  def nextBytes(size: Int): F[BitVector]
+}
+
+object RandomProvider {
+  implicit def SecureR[F[_]: Sync]: RandomProvider[F] = {
+    val secrand = new SecureRandom() //TODO: Expensive to create, should be moved to instance field (side effecty as well)
+    size: Int =>
+      Sync[F].delay {
+        val byteArray = Array.fill[Byte](size)(0)
+        secrand.nextBytes(byteArray)
+        BitVector(byteArray)
+      }
+  }
+}

--- a/auth0/src/main/scala/io/unsecurity/auth/auth0/oidc/SessionStore.scala
+++ b/auth0/src/main/scala/io/unsecurity/auth/auth0/oidc/SessionStore.scala
@@ -4,11 +4,11 @@ package oidc
 
 import java.net.URI
 
-trait SessionStore[A] {
-  def storeState(stateRef: String, state: String, returnToUrl: URI, callbackUrl: URI): Unit
-  def getState(stateRef: String): Option[State]
-  def removeState(stateRef: String): Unit
-  def storeSession(key: String, content: A): Unit
-  def getSession(key: String): Option[A]
-  def removeSession(key: String): Unit
+trait SessionStore[F[_], A] {
+  def storeState(stateRef: String, state: String, returnToUrl: URI, callbackUrl: URI): F[Unit]
+  def getState(stateRef: String): F[Option[State]]
+  def removeState(stateRef: String): F[Unit]
+  def storeSession(key: String, content: A): F[Unit]
+  def getSession(key: String): F[Option[A]]
+  def removeSession(key: String): F[Unit]
 }

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ ThisBuild / crossScalaVersions := Seq("2.12.8", "2.11.12")
 ThisBuild / scalaVersion := crossScalaVersions.value.head
 ThisBuild / useGpg := true
 
-lazy val root = (project in file("."))
+lazy val root = (project in file(".")).settings(name := "unsecurity")
   .aggregate(core, auth0)
 
 lazy val core = project

--- a/core/src/main/scala/io/unsecurity/Unsecurity2.scala
+++ b/core/src/main/scala/io/unsecurity/Unsecurity2.scala
@@ -32,17 +32,10 @@ abstract class Unsecurity2[F[_]: Sync, RU, U] extends AbstractUnsecurity2[F, U] 
           a2dc =>
             a2dc.andThen(
               dc =>
-                dc.flatMap(
-                  c =>
-                    if (predicate(c)) {
-                      Directive.success(c)
-                    } else {
-                      Directive.error(
-                        Response[F]()
-                          .withStatus(Status.Forbidden)
-                      )
-                  }
-              )
+                Directive.commit(
+                  dc.filter(
+                    c => predicate(c).orF(Sync[F].pure(Response[F](Status.Forbidden)))
+                  ))
           )),
         entityEncoder = entityEncoder
       )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.7
+sbt.version=1.2.8


### PR DESCRIPTION
Drop use of OkHttp and replace with http4s client
Replace use of OkIO with scodec-bits

SessionStore is now effectful
Removed a scary implicit conversion in UnsecurityOps

Some other minor cleanups