### PR TITLE
Update auth0 dependencies

### DIFF
--- a/auth0/build.sbt
+++ b/auth0/build.sbt
@@ -8,8 +8,8 @@ scalacOptions := Seq(
 )
 
 libraryDependencies := Seq(
-  "com.auth0"            % "auth0"            % "1.10.0",
-  "com.auth0"            % "jwks-rsa"         % "0.7.0",
-  "com.auth0"            % "java-jwt"         % "3.7.0",
+  "com.auth0"            % "auth0"            % "1.14.1",
+  "com.auth0"            % "jwks-rsa"         % "0.8.2",
+  "com.auth0"            % "java-jwt"         % "3.8.1",
   "org.scalatest"        %% "scalatest"       % "3.0.6" % Test
 )


### PR DESCRIPTION
This version of auth0 is using a version of  jackson-databind containg vulnerabilities
(https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-12814)