### PR TITLE
Allow whole issuer to be specified

### DIFF
--- a/auth0/src/main/scala/io/unsecurity/auth/auth0/AuthConfig.scala
+++ b/auth0/src/main/scala/io/unsecurity/auth/auth0/AuthConfig.scala
@@ -5,7 +5,7 @@ import java.net.URI
 
 case class AuthConfig(clientId: String,
                       clientSecret: String,
-                      authDomain: String,
+                      issuer: String,
                       defaultAuth0CallbackUrl: URI,
                       defaultReturnToUrl: URI,
                       returnToUrlDomainWhitelist: List[String],

--- a/auth0/src/main/scala/io/unsecurity/auth/auth0/oidc/TokenVerifier.scala
+++ b/auth0/src/main/scala/io/unsecurity/auth/auth0/oidc/TokenVerifier.scala
@@ -33,12 +33,12 @@ object TokenVerifier {
   }
 
   def validateIdToken(alg: Algorithm,
-                      authDomain: String,
+                      issuer: String,
                       clientId: String,
                       idToken: String): Either[String, OidcAuthenticatedUser] = {
     val verifier = JWT
       .require(alg)
-      .withIssuer(s"https://$authDomain/")
+      .withIssuer(issuer)
       .withAudience(clientId)
       .build()
 

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -4,7 +4,7 @@ scalacOptions := Seq("-deprecation", "-Ypartial-unification", "-language:higherK
 
 val http4sVersion     = "0.20.11"
 val circeVersion      = "0.12.2"
-val directivesVersion = "0.14.0"
+val directivesVersion = "0.13.0"
 
 libraryDependencies := Seq(
   "io.circe"           %% "circe-parser"        % circeVersion,

--- a/core/src/main/scala/io/unsecurity/Unsecurity.scala
+++ b/core/src/main/scala/io/unsecurity/Unsecurity.scala
@@ -1,6 +1,7 @@
 package io
 package unsecurity
 
+import cats.data.NonEmptyList
 import cats.effect.Sync
 import io.unsecurity.hlinx.HLinx.HLinx
 import io.unsecurity.hlinx.{ReversedTupled, SimpleLinx, TransformParams}
@@ -224,7 +225,7 @@ abstract class Unsecurity[F[_]: Sync, RU, U] extends AbstractUnsecurity[F, U] wi
       )
     }
     override def compile: PathMatcher[Response[F]] = {
-      def allow(methods: Set[Method]): Allow = Allow(methods)
+      def allow(methods: Set[Method]): Allow = Allow(NonEmptyList.fromListUnsafe(methods.toList))
 
       pathMatcher.andThen { pathParamsDirective =>
         for {


### PR DESCRIPTION
This is contrary to using string concatenation to build up an URL.

The reason for this is that EG. token verification does a strict
comparison between supplied issuer and the iss property of the JWT. An
issuer however may not have an ending "/". An issuer may for instance
have an URL component part.

Allowing the whole issuer to be supplied gives the consumer more
flexibility. Right now, the library is somewhere between a) being
tightly coupled to Auth0 and b) only coupled to the OpenID interface.
This takes it somewhat closer to b). Being close to b) and removing
traces of Auth0 would open it up to a whole class of providers.

I've found some other things that ensures that we're still at a).

  1. Unsecurity expects to receive claim values from the ID Token, but I
  believe this is optional according to the spec [1]. To be certain of
  the availability, the userinfo endpoint should be requested.

  2. We're sending JSON-encoded requests to the token endpoint. This is
  not in accordance with the spec [2-3], albeit many providers allow it
  (and it so happens that Auth0 is one of them).

  3. The URL for the token endpoint is statically coded, but may take
  different form for different providers. To fully comply, one should
  perform a dicovery by requesting the well known configuration URL and
  use the returned information to make further requests.

[1] https://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims
[2] https://openid.net/specs/openid-connect-core-1_0.html#TokenRequest
[3] https://tools.ietf.org/html/rfc6749#section-4.1.3