### PR TITLE
Path matcher uses pathInfo instead of uri.path

### DIFF
--- a/core/src/main/scala/io/unsecurity/UnsecurityPlan.scala
+++ b/core/src/main/scala/io/unsecurity/UnsecurityPlan.scala
@@ -32,5 +32,5 @@ class UnsecurityPlan[F[_]](implicit M: MonadError[F, Throwable]) {
     }
   }
 
-  lazy val PathMapping: Mapping[Uri.Path] = Mapping[Uri.Path](r => r.uri.path)
+  lazy val PathMapping: Mapping[Uri.Path] = Mapping[Uri.Path](r => r.pathInfo)
 }


### PR DESCRIPTION
Pathinfo recognizes the context route that may have been specified when using http4s Router