### PR TITLE
Accept http deletes without content type header. 

### DIFF
--- a/core/src/main/scala/io/unsecurity/AbstractContentTypeMatcher.scala
+++ b/core/src/main/scala/io/unsecurity/AbstractContentTypeMatcher.scala
@@ -2,7 +2,7 @@ package io.unsecurity
 
 import cats.Monad
 import no.scalabin.http4s.directives.Directive
-import org.http4s.Method.GET
+import org.http4s.Method.{GET, DELETE}
 import org.http4s.implicits._
 import org.http4s.headers.`Content-Type`
 
@@ -17,7 +17,7 @@ abstract class AbstractContentTypeMatcher[F[_]: Monad] extends AbstractMethodMat
       method  = request.method
       contentType <- request.headers
                       .get(`Content-Type`)
-                      .orElse { if (method == GET) Some(`Content-Type`.apply(WILDCARD)) else None }
+                      .orElse { if (method == GET || method == DELETE) Some(`Content-Type`.apply(WILDCARD)) else None }
                       .toSuccess(
                         HttpProblem
                           .unsupportedMediaType(

--- a/core/src/main/scala/io/unsecurity/AbstractContentTypeMatcher.scala
+++ b/core/src/main/scala/io/unsecurity/AbstractContentTypeMatcher.scala
@@ -15,8 +15,7 @@ abstract class AbstractContentTypeMatcher[F[_]: Monad] extends AbstractMethodMat
     for {
       request <- Directive.request[F]
       method  = request.method
-      suppliedContentType: Option[`Content-Type`] = request.headers
-        .get(`Content-Type`)
+      suppliedContentType = request.headers.get(`Content-Type`)
       contentType <- suppliedContentType
                       .orElse { if (method == GET || method == DELETE) Some(`Content-Type`.apply(WILDCARD)) else None }
                       .toSuccess(
@@ -31,7 +30,7 @@ abstract class AbstractContentTypeMatcher[F[_]: Monad] extends AbstractMethodMat
                 mediaRangeMap.get(contentType.mediaType).toSuccess { supportedMediaTypes =>
                   Directive.error(
                     HttpProblem
-                      .unsupportedMediaType(s"Content-Type '${suppliedContentType.map(_.value).getOrElse("not specified")}' invalid or unsupported mediatype", supportedMediaTypes)
+                      .unsupportedMediaType(s"Content-Type '${contentType.mediaType}' invalid or unsupported mediatype", supportedMediaTypes)
                       .toResponse
                   )
                 }

--- a/core/src/main/scala/io/unsecurity/AbstractUnsecurity.scala
+++ b/core/src/main/scala/io/unsecurity/AbstractUnsecurity.scala
@@ -172,7 +172,7 @@ case class MediaRangeMap[A](mr2a2rdf: List[(Set[MediaRange], A)]) {
       .find {
         case (mrs, _) =>
           mrs.exists { mr =>
-            mr.satisfiedBy(mediaRange)
+            mr.satisfiedBy(mediaRange) && mediaRange.extensions.forall{case (prop, value) => mr.extensions.get(prop).contains(value)}
           }
       }
       .map(_._2)

--- a/core/src/main/scala/io/unsecurity/HttpProblem.scala
+++ b/core/src/main/scala/io/unsecurity/HttpProblem.scala
@@ -54,6 +54,18 @@ object HttpProblem {
     )
   )
 
+  implicit val httpProblemDecoder: Decoder[HttpProblem] = (c: HCursor) => {
+    for {
+      title  <- c.downField("title").as[String]
+      status <- c.downField("status").as[Status]
+      detail <- c.downField("detail").as[Option[String]]
+      data   <- c.downField("data").as[Option[Json]]
+      uuid   <- c.downField("errorId").as[String]
+
+    } yield HttpProblem(status, title, detail, data, uuid)
+
+  }
+
   def methodNotAllowed(title: String, allowedMethods: Set[Method]) =
     HttpProblem(Status.MethodNotAllowed,
                 title,

--- a/core/src/main/scala/io/unsecurity/HttpProblem.scala
+++ b/core/src/main/scala/io/unsecurity/HttpProblem.scala
@@ -10,6 +10,7 @@ import org.http4s.circe.DecodingFailures
 import org.http4s._
 import org.log4s.getLogger
 
+import scala.util.Success
 import scala.util.control.NonFatal
 
 // https://tools.ietf.org/html/rfc7807
@@ -65,6 +66,9 @@ object HttpProblem {
     } yield HttpProblem(status, title, detail, data, uuid)
 
   }
+
+  implicit val statusDecoder: Decoder[Status] = Decoder.decodeInt.emapTry(i => Status.fromInt(i).toTry.orElse(Success(Status.InternalServerError)))
+
 
   def methodNotAllowed(title: String, allowedMethods: Set[Method]) =
     HttpProblem(Status.MethodNotAllowed,

--- a/core/src/test/scala/io/unsecurity/ContentTypeMatcherTest.scala
+++ b/core/src/test/scala/io/unsecurity/ContentTypeMatcherTest.scala
@@ -61,6 +61,15 @@ class ContentTypeMatcherTest extends UnsecurityTestSuite {
     }
   }
 
+  test("Allows delete without content-type") {
+    val mediaRangeMap        = MediaRangeMap(List(Set(MediaRange.`*/*`) -> "dingdong"))
+    val get                  = Request[Id](method = Method.DELETE, uri = uri"/whatever")
+    val contentTypeDirective = contentTypeMatcher.matchContentType(mediaRangeMap)
+    contentTypeDirective.run(get).where {
+      case Result.Success("dingdong") => Ok
+    }
+  }
+
   test("Content-type matching allows properties") {
     val mediaRangeMap = MediaRangeMap(List(supportedMediaRange))
     val requestWithVersionedContentType =

--- a/core/src/test/scala/io/unsecurity/ContentTypeMatcherTest.scala
+++ b/core/src/test/scala/io/unsecurity/ContentTypeMatcherTest.scala
@@ -1,6 +1,7 @@
 package io.unsecurity
 
 import cats.Id
+import cats.implicits._
 import no.scalabin.http4s.directives.Result
 import org.http4s.headers.`Content-Type`
 import org.http4s.implicits._
@@ -10,6 +11,9 @@ class ContentTypeMatcherTest extends UnsecurityTestSuite {
   val contentTypeMatcher: AbstractContentTypeMatcher[Id] = new AbstractContentTypeMatcher[Id] {}
 
   val problemJsonContentType = `Content-Type`(mediaType"application/problem+json")
+
+  val versionedMediaTypeReq = Request[Id](method= Method.POST, uri = uri"/whatever", headers=Headers.of(Header("content-type", "application/vnd.custom;version=1")))
+  val unversionedMediaTypeReq = Request[Id](method= Method.POST, uri = uri"/whatever", headers=Headers.of(Header("content-type", "application/vnd.custom")))
 
   val invalidMediaType =
     Request[Id](method = Method.POST, uri = uri"/whatever", headers = Headers.of(Header("content-type", "foobar")))
@@ -40,6 +44,7 @@ class ContentTypeMatcherTest extends UnsecurityTestSuite {
       case Result.Error(r)
           if r.status == Status.UnsupportedMediaType
             && r.contentType.contains(problemJsonContentType) =>
+        println(r.bodyAsText.compile.last)
         Ok
     }
   }
@@ -70,15 +75,45 @@ class ContentTypeMatcherTest extends UnsecurityTestSuite {
     }
   }
 
-  test("Content-type matching allows properties") {
-    val mediaRangeMap = MediaRangeMap(List(supportedMediaRange))
-    val requestWithVersionedContentType =
-      Request[Id](method = Method.POST,
-                  uri = uri"/whatever",
-                  headers = Headers.of(Header("content-type", "application/fjon;version=1")))
+  test("Request with versioned Content-type with matching server") {
+    val versionedMediaRange = MediaRange.parse("application/vnd.custom;version=1")
+    val versionedMediaType = Set(versionedMediaRange.toOption.get) -> "spjong"
+    val mediaRangeMap = MediaRangeMap(List(versionedMediaType))
     val contentTypeMatchDirective = contentTypeMatcher.matchContentType(mediaRangeMap)
-    contentTypeMatchDirective.run(requestWithVersionedContentType).where {
-      case Result.Success("dingdong") => Ok
+    contentTypeMatchDirective.run(versionedMediaTypeReq).where {
+      case Result.Success("spjong") => Ok
+    }
+  }
+
+  test("Request with versioned Content-type fails when server does not have specified version") {
+    val versionedMediaRange = MediaRange.parse("application/vnd.custom;version=2")
+    val versionedMediaType = Set(versionedMediaRange.toOption.get) -> "spjong"
+    val mediaRangeMap = MediaRangeMap(List(versionedMediaType))
+    val contentTypeMatchDirective = contentTypeMatcher.matchContentType(mediaRangeMap)
+    contentTypeMatchDirective.run(versionedMediaTypeReq).where {
+      case Result.Error(r) if(r.status == Status.UnsupportedMediaType) => Ok
+    }
+  }
+
+  test("Request with versioned Content-type fails when server is unversioned") {
+    val versionedMediaRange = MediaRange.parse("application/vnd.custom")
+    val versionedMediaType = Set(versionedMediaRange.toOption.get) -> "spjong"
+    val mediaRangeMap = MediaRangeMap(List(versionedMediaType))
+    val contentTypeMatchDirective = contentTypeMatcher.matchContentType(mediaRangeMap)
+    contentTypeMatchDirective.run(versionedMediaTypeReq).where {
+      case Result.Error(r) if(r.status == Status.UnsupportedMediaType) => Ok
+    }
+  }
+
+  test("Request without versioned Content-type succeeds when server has versioned content") {
+    val version2Endpoint = Set(MediaRange.parse("application/vnd.custom;version=2").toOption.get) -> "welcome to version 2"
+    val version1Endpoint = Set(MediaRange.parse("application/vnd.custom;version=1").toOption.get) -> "welcome to version 1"
+    val mediaRangeMap = MediaRangeMap(List(version2Endpoint, version1Endpoint))
+    val contentTypeMatchDirective = contentTypeMatcher.matchContentType(mediaRangeMap)
+    contentTypeMatchDirective.run(unversionedMediaTypeReq).where {
+      case Result.Success("welcome to version 2") => Ok
+      case Result.Success(_) => Fail("Expected to reach version 2 endpoint, as it was defined first in list and no versiopn specified in request")
+      case Result.Error(r) => Fail(r.bodyAsText.compile.last.toString)
     }
   }
 


### PR DESCRIPTION
If delete is done without a content-type header 415 is returned. This fixes that, allowing header to be unspecified in case of delete.
Also adds httpproblem circe decoder