### PR TITLE
Include `data` when creating internal server errors

### DIFF
--- a/core/src/main/scala/io/unsecurity/HttpProblem.scala
+++ b/core/src/main/scala/io/unsecurity/HttpProblem.scala
@@ -86,7 +86,7 @@ object HttpProblem {
     HttpProblem(Status.Unauthorized, title, detail, None)
 
   def internalServerError(title: String, detail: Option[String] = None, data: Option[Json] = None) =
-    HttpProblem(Status.InternalServerError, title, detail, None)
+    HttpProblem(Status.InternalServerError, title, detail, data)
 
   def notFound = HttpProblem(Status.NotFound, "Not Found", None, None)
 


### PR DESCRIPTION
This appears to have been left out by accident and prevents the
application from forwarding the correct data associated with an internal
server error, which in turn makes it harder to debug applications.

An example of this can be found in Auth0OidcSecurityContext.scala:200,
where the `data` parameter is used to provide the actual error message.