### PR TITLE
Improve validation for URL parameters for auth0

### DIFF
--- a/auth0/src/main/scala/io/unsecurity/auth/auth0/oidc/Auth0OidcSecurityContext.scala
+++ b/auth0/src/main/scala/io/unsecurity/auth/auth0/oidc/Auth0OidcSecurityContext.scala
@@ -2,7 +2,7 @@ package io.unsecurity
 package auth.auth0
 package oidc
 
-import java.net.URI
+import java.net.URL
 import java.security.interfaces.RSAPublicKey
 
 import cats.data.EitherT
@@ -121,7 +121,7 @@ class Auth0OidcSecurityContext[F[_]: Sync, U](val authConfig: AuthConfig,
     )
   }
 
-  def createAuth0Url(state: String, auth0CallbackUrl: URI): String = {
+  def createAuth0Url(state: String, auth0CallbackUrl: URL): String = {
     new AuthAPI(authConfig.issuer, authConfig.clientId, authConfig.clientSecret)
       .authorizeUrl(auth0CallbackUrl.toString)
       .withScope("openid profile email")
@@ -152,7 +152,7 @@ class Auth0OidcSecurityContext[F[_]: Sync, U](val authConfig: AuthConfig,
     } yield sessionState
   }
 
-  def isReturnUrlWhitelisted(uri: URI): Boolean = {
+  def isReturnUrlWhitelisted(uri: URL): Boolean = {
     authConfig.returnToUrlDomainWhitelist.contains(uri.getHost)
   }
 
@@ -168,7 +168,7 @@ class Auth0OidcSecurityContext[F[_]: Sync, U](val authConfig: AuthConfig,
     }
   }
 
-  def fetchTokenFromAuth0(code: String, auth0CallbackUrl: URI): Directive[F, TokenResponse] = {
+  def fetchTokenFromAuth0(code: String, auth0CallbackUrl: URL): Directive[F, TokenResponse] = {
     val tokenUrl      = Uri.unsafeFromString(authConfig.issuer) / "oauth" / "token"
     val jsonMediaType = MediaType.application.json
     val payload = TokenRequest(grantType = "authorization_code",
@@ -283,7 +283,7 @@ class Auth0OidcSecurityContext[F[_]: Sync, U](val authConfig: AuthConfig,
 
 }
 
-case class TokenRequest(grantType: String, clientId: String, clientSecret: String, code: String, redirectUri: URI)
+case class TokenRequest(grantType: String, clientId: String, clientSecret: String, code: String, redirectUri: URL)
 
 object TokenRequest {
   implicit val tokenRequestEncoder: Encoder[TokenRequest] = Encoder { tr =>

--- a/auth0/src/main/scala/io/unsecurity/auth/auth0/oidc/AuthConfig.scala
+++ b/auth0/src/main/scala/io/unsecurity/auth/auth0/oidc/AuthConfig.scala
@@ -1,15 +1,36 @@
 package io.unsecurity.auth.auth0.oidc
 
-import java.net.URI
+import java.net.{URL, URI}
 
 import scala.concurrent.duration.FiniteDuration
 
 case class AuthConfig(clientId: String,
                       clientSecret: String,
                       issuer: String,
-                      defaultAuth0CallbackUrl: URI,
-                      defaultReturnToUrl: URI,
+                      defaultAuth0CallbackUrl: URL,
+                      defaultReturnToUrl: URL,
                       returnToUrlDomainWhitelist: List[String],
-                      afterLogoutUrl: URI,
+                      afterLogoutUrl: URL,
                       sessionCookieTtl: Option[FiniteDuration],
                       cookieName: String)
+
+object AuthConfig {
+  def apply(clientId: String,
+            clientSecret: String,
+            issuer: String,
+            defaultAuth0CallbackUrl: URI,
+            defaultReturnToUrl: URI,
+            returnToUrlDomainWhitelist: List[String],
+            afterLogoutUrl: URI,
+            sessionCookieTtl: Option[FiniteDuration],
+            cookieName: String): AuthConfig = AuthConfig(
+    clientId,
+    clientSecret,
+    issuer,
+    defaultAuth0CallbackUrl.toURL,
+    defaultReturnToUrl.toURL,
+    returnToUrlDomainWhitelist,
+    afterLogoutUrl.toURL,
+    sessionCookieTtl,
+    cookieName)
+}

--- a/auth0/src/main/scala/io/unsecurity/auth/auth0/oidc/State.scala
+++ b/auth0/src/main/scala/io/unsecurity/auth/auth0/oidc/State.scala
@@ -2,7 +2,7 @@ package io.unsecurity.auth
 package auth0
 package oidc
 
-import java.net.URI
+import java.net.URL
 
 import io.circe.{Decoder, Encoder, Json}
 import io.circe.syntax._
@@ -11,27 +11,27 @@ import scala.util.Try
 
 case class State(
     state: String,
-    returnToUrl: URI,
-    callbackUrl: URI,
+    returnToUrl: URL,
+    callbackUrl: URL,
     additionalData: String
 )
 
 object State {
-  implicit val decodeURI: Decoder[URI] =
+  implicit val decodeURI: Decoder[URL] =
     Decoder.decodeString.flatMap { str =>
       Decoder.instanceTry { _ =>
-        Try(URI.create(str))
+        Try(new URL(str))
       }
     }
 
-  implicit val encodeURI: Encoder[URI] =
+  implicit val encodeURI: Encoder[URL] =
     uri => Json.fromString(uri.toString)
 
   implicit val decodeState: Decoder[State] = Decoder[State] { c =>
     for {
       state          <- c.downField("state").as[String]
-      returnToUrl    <- c.downField("returnToUrl").as[URI]
-      callbackUrl    <- c.downField("callbackUrl").as[URI]
+      returnToUrl    <- c.downField("returnToUrl").as[URL]
+      callbackUrl    <- c.downField("callbackUrl").as[URL]
       additionalData <- c.downField("additionalData").as[String]
     } yield {
       State(


### PR DESCRIPTION
Passing invalid URLs (for instance without a scheme) has so far
triggered NullPointerExceptions, and some other invalid cases also
triggered errors when passing the URL on to Auth0.